### PR TITLE
ci: use rubygems-requirements-system for installing gem gobject-introspection dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+plugin "rubygems-requirements-system"
+
 gemspec
 
 group :test do


### PR DESCRIPTION
## Problem

CI builds are failing during gem installation because
the `gobject-introspection` gem cannot find the
`girepository.h` header file.

```
Installing gobject-introspection 4.2.7 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/home/runner/work/red_amber/red_amber/vendor/bundle/ruby/3.3.0/gems/gobject-introspection-4.2.7/ext/gobject-introspection
/opt/hostedtoolcache/Ruby/3.3.7/x64/bin/ruby extconf.rb
checking for --enable-debug-build option... no
checking for -Wall option to compiler... yes
checking for -Wcast-align option to compiler... yes
checking for -Wextra option to compiler... yes
checking for -Wformat=2 option to compiler... yes
checking for -Winit-self option to compiler... yes
checking for -Wlarger-than-65500 option to compiler... yes
checking for -Wmissing-declarations option to compiler... yes
checking for -Wmissing-format-attribute option to compiler... yes
checking for -Wmissing-include-dirs option to compiler... yes
checking for -Wmissing-noreturn option to compiler... yes
checking for -Wmissing-prototypes option to compiler... yes
checking for -Wnested-externs option to compiler... yes
checking for -Wold-style-definition option to compiler... yes
checking for -Wpacked option to compiler... yes
checking for -Wp,-D_FORTIFY_SOURCE=2 option to compiler... no
checking for -Wpointer-arith option to compiler... yes
checking for -Wundef option to compiler... yes
checking for -Wout-of-line-declaration option to compiler... no
checking for -Wunsafe-loop-optimizations option to compiler... yes
checking for -Wwrite-strings option to compiler... yes
checking for Homebrew... no
checking for gobject-introspection-1.0... yes (1.80.1)
creating rbgiversion.h
creating gobject-introspection-enum-types.c
creating gobject-introspection-enum-types.h
creating ruby-gobject-introspection.pc
creating Makefile

current directory:
/home/runner/work/red_amber/red_amber/vendor/bundle/ruby/3.3.0/gems/gobject-introspection-4.2.7/ext/gobject-introspection
make DESTDIR\= sitearchdir\=./.gem.20250318-4050-aavnxv
sitelibdir\=./.gem.20250318-4050-aavnxv clean

current directory:
/home/runner/work/red_amber/red_amber/vendor/bundle/ruby/3.3.0/gems/gobject-introspection-4.2.7/ext/gobject-introspection
make DESTDIR\= sitearchdir\=./.gem.20250318-4050-aavnxv
sitelibdir\=./.gem.20250318-4050-aavnxv
compiling gobject-introspection-enum-types.c
gobject-introspection-enum-types.c:5:10: fatal error: girepository.h: No such
file or directory
    5 | #include <girepository.h>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:248: gobject-introspection-enum-types.o] Error 1

make failed, exit code 2
```

## Cause

The `gobject-introspection` gem depends on
`libgirepository1.0-dev`, which is not automatically
downloaded during gem installation. It leads to a
missing header error.

## Solution

Using the `rubygems-requirements-system` plugin to the
Gemfile so that the required `libgirepository1.0-dev`
as gobject-introspection's dependency is automatically
fetched during gem installation.